### PR TITLE
StackOverflowError in sources containing non-simple annotations

### DIFF
--- a/janino/src/org/codehaus/janino/Java.java
+++ b/janino/src/org/codehaus/janino/Java.java
@@ -386,7 +386,7 @@ class Java {
         }
 
         @Override public void
-        setEnclosingScope(Scope enclosingScope) { this.setEnclosingScope(enclosingScope); }
+        setEnclosingScope(Scope enclosingScope) { this.type.setEnclosingScope(enclosingScope); }
 
         @Override public void
         accept(Visitor.AnnotationVisitor visitor) { visitor.visitNormalAnnotation(this); }


### PR DESCRIPTION
Hi,

First off, thanks for maintaining this library, it's very useful !

I've noticed that the following error occurs with Janino 2.7.7, when loading some Java sources that contain annotations with parameters (for instance: ```@JsonProperty(value = "element")```):
```
Exception in thread "main" java.lang.StackOverflowError
        at org.codehaus.janino.Java$NormalAnnotation.setEnclosingScope(Java.java:389)
        at org.codehaus.janino.Java$NormalAnnotation.setEnclosingScope(Java.java:389)
```

The fix uses same implementation as org.codehaus.janino.Java.SingleElementAnnotation#setEnclosingScope 
I've successfully tested the fix in my project that uses Janino.

Regards,
Romain