### PR TITLE
Fix parsing error for annotations with multiple elements

### DIFF
--- a/janino/src/org/codehaus/janino/Parser.java
+++ b/janino/src/org/codehaus/janino/Parser.java
@@ -358,7 +358,12 @@ class Parser {
         }
 
         List<Java.ElementValuePair> evps = new ArrayList();
-        while (!this.peekRead(")")) evps.add(this.parseElementValuePair());
+        while (!this.peekRead(")")) {
+            if(!evps.isEmpty()){
+                this.read(",");
+            }
+            evps.add(this.parseElementValuePair());
+        }
 
         return new Java.NormalAnnotation(
             type,


### PR DESCRIPTION
Hi,

As a follow-up of https://github.com/aunkrig/janino/pull/1, I've noticed a parsing error for annotations with multiple elements, causing a CompileException: Identifier expected instead of ','
For instance parsing such annotation:
`@Size(min = 1, max = 25, message ="Too long")`

This is caused by the commas not being consumed by the parser, so it fails as soon as the annotation has more than 1 element.

Regards,
Romain